### PR TITLE
Add phoenix chat app

### DIFF
--- a/rails_v._phoenix_chat/phoenix_chat/README.md
+++ b/rails_v._phoenix_chat/phoenix_chat/README.md
@@ -18,5 +18,142 @@ Now we can fire up our app with: `mix phoenix.start`.
 
 ## Step 2 - Create Chat Page
 
+Phoenix helpfully provides us with a default view and controller and controller spec. So we'll just update the view to hold our chat and update the test to check for it.
+
+#### Test
+`test/controllers/page_controller_test.exs`
+```Elixir
+test "Page has Chat Banner", %{conn: conn} do
+  conn = get conn, "/"
+  assert html_response(conn, 200) =~ "Welcome to the Chat Room"
+end
+```
+
+#### View
+`web/templates/page/index.html.eex`
+```ERB
+<h1>Welcome to the Chat Room</h1>
+
+<div id="chat-box">
+  <span>Messages: </span>
+</div>
+
+<form id="message-form">
+  <input type="text" id="message-input"/>
+  <input type="submit" />
+</form>
+```
 
 ## Step 3 - Sending and Receiving Messages
+
+Phoenix has [build in channel test helpers](https://hexdocs.pm/phoenix/Phoenix.ChannelTest.html) so we can test channels pretty easily:
+
+#### Test
+`test/channel/chat_channel_test.exs`
+```Elixir
+defmodule PhoenixChat.ChatChannelTest do
+  use PhoenixChat.ChannelCase
+  alias PhoenixChat.ChatChannel
+
+  test "messages are rebroadcast" do
+    {:ok, _, socket} = socket("", %{})
+      |> subscribe_and_join(ChatChannel, "chat")
+
+    message = %{"message" => "body"}
+
+    push socket, "message", message
+    assert_broadcast "message", message
+  end
+end
+```
+
+First we stub out the socket with the `socket` helper and subscribe to the socket. Then we're just gonna push a test message to the channel and assert that the same message is rebroadcast out.
+
+Now we need to fill in all the code to make that test pass. First we need to define the channel in our socket. We'll use the default UserSocket file somewhere near the top of the file:
+
+#### Socket
+`web/channels/user_socket.ex`
+```Elixir
+## Channels
+channel "chat", PhoenixChat.ChatChannel
+```
+
+And now we need to define our channel behavior. We will write two functions, one for handling the join call and one for handling incoming messages. If we wanted to implement authentication that would take place in the `UserSocket.connect/2` function. The `join/3` function can be used to handle actions after a user has joined a channel. The `handle_in/3` function can be used to define all kinds of actions that the channel can accommodate via pattern matching. In our case we are defining the `message` action.
+
+#### Channel
+`web/channels/chat_channel.ex`
+```Elixir
+defmodule PhoenixChat.ChatChannel do
+  use Phoenix.Channel
+
+  def join("chat", _payload, socket) do
+    {:ok, socket}
+  end
+
+  def handle_in("message", payload, socket) do
+    broadcast! socket, "message", payload
+    {:noreply, socket}
+  end
+end
+```
+
+Now we just need to implement the front end client. First we are going to include jQuery so we can easily manipulate the DOM. We'll do that in the appliation layout. Make sure it is included before the rest of the JS:
+
+#### Layout
+`web/templates/layout/app.html.eex`
+```ERB
+.
+.
+.
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+<link rel="stylesheet" href="<%= static_path(@conn, "/css/app.css") %>">
+.
+.
+.
+```
+
+Now we can use the simple socket lib that ships with Phoenix. This is a simple matter of uncommenting it in the app.js file:
+
+#### App.js
+`web/static/js/app.js`
+```JS
+import socket from "./socket"
+```
+
+Now we can open the socket lib and add our custom chat code. First connect to the default websocket. Next we add our channel/message handling code. We want to display messages when we receive a `message` action and we want to send messages when the user interacts with the input field. Finally we subscribe to our chat channel.
+
+#### Client
+`web/static/js/socket.js`
+```JS
+import {Socket} from "phoenix"
+
+let socket = new Socket("/socket", {})
+
+socket.connect()
+
+// Now that you are connected, you can join channels with a topic:
+let channel = socket.channel("chat", {})
+
+channel.on('message', payload => {
+  $('#chat-box').append(`<div>${payload.message}</div>`);
+});
+
+$('#message-form').submit(e => {
+  e.preventDefault();
+
+  let message = $('#message-input');
+
+  if (message.val().length > 0) {
+    channel.push('message', { message: message.val() });
+    message.val('');
+  }
+});
+
+channel.join()
+  .receive("ok", resp => { console.log("Joined successfully", resp) })
+  .receive("error", resp => { console.log("Unable to join", resp) })
+
+export default socket
+```
+
+And thats it! Prett slick.

--- a/rails_v._phoenix_chat/phoenix_chat/test/channels/chat_channel_test.exs
+++ b/rails_v._phoenix_chat/phoenix_chat/test/channels/chat_channel_test.exs
@@ -1,0 +1,14 @@
+defmodule PhoenixChat.ChatChannelTest do
+  use PhoenixChat.ChannelCase
+  alias PhoenixChat.ChatChannel
+
+  test "messages are rebroadcast" do
+    {:ok, _, socket} = socket("", %{})
+      |> subscribe_and_join(ChatChannel, "chat")
+
+    message = %{"message" => "body"}
+
+    push socket, "message", message
+    assert_broadcast "message", message
+  end
+end

--- a/rails_v._phoenix_chat/phoenix_chat/test/controllers/page_controller_test.exs
+++ b/rails_v._phoenix_chat/phoenix_chat/test/controllers/page_controller_test.exs
@@ -1,8 +1,8 @@
 defmodule PhoenixChat.PageControllerTest do
   use PhoenixChat.ConnCase
 
-  test "GET /", %{conn: conn} do
+  test "Page has Chat Banner", %{conn: conn} do
     conn = get conn, "/"
-    assert html_response(conn, 200) =~ "Welcome to Phoenix!"
+    assert html_response(conn, 200) =~ "Welcome to the Chat Room"
   end
 end

--- a/rails_v._phoenix_chat/phoenix_chat/web/channels/chat_channel.ex
+++ b/rails_v._phoenix_chat/phoenix_chat/web/channels/chat_channel.ex
@@ -1,0 +1,12 @@
+defmodule PhoenixChat.ChatChannel do
+  use Phoenix.Channel
+
+  def join("chat", _payload, socket) do
+    {:ok, socket}
+  end
+
+  def handle_in("message", payload, socket) do
+    broadcast! socket, "message", payload
+    {:noreply, socket}
+  end
+end

--- a/rails_v._phoenix_chat/phoenix_chat/web/channels/user_socket.ex
+++ b/rails_v._phoenix_chat/phoenix_chat/web/channels/user_socket.ex
@@ -2,7 +2,7 @@ defmodule PhoenixChat.UserSocket do
   use Phoenix.Socket
 
   ## Channels
-  # channel "room:*", PhoenixChat.RoomChannel
+  channel "chat", PhoenixChat.ChatChannel
 
   ## Transports
   transport :websocket, Phoenix.Transports.WebSocket

--- a/rails_v._phoenix_chat/phoenix_chat/web/static/js/app.js
+++ b/rails_v._phoenix_chat/phoenix_chat/web/static/js/app.js
@@ -18,4 +18,4 @@ import "phoenix_html"
 // Local files can be imported directly using relative
 // paths "./socket" or full ones "web/static/js/socket".
 
-// import socket from "./socket"
+import socket from "./socket"

--- a/rails_v._phoenix_chat/phoenix_chat/web/static/js/socket.js
+++ b/rails_v._phoenix_chat/phoenix_chat/web/static/js/socket.js
@@ -5,56 +5,28 @@
 // and connect at the socket path in "lib/my_app/endpoint.ex":
 import {Socket} from "phoenix"
 
-let socket = new Socket("/socket", {params: {token: window.userToken}})
-
-// When you connect, you'll often need to authenticate the client.
-// For example, imagine you have an authentication plug, `MyAuth`,
-// which authenticates the session and assigns a `:current_user`.
-// If the current user exists you can assign the user's token in
-// the connection for use in the layout.
-//
-// In your "web/router.ex":
-//
-//     pipeline :browser do
-//       ...
-//       plug MyAuth
-//       plug :put_user_token
-//     end
-//
-//     defp put_user_token(conn, _) do
-//       if current_user = conn.assigns[:current_user] do
-//         token = Phoenix.Token.sign(conn, "user socket", current_user.id)
-//         assign(conn, :user_token, token)
-//       else
-//         conn
-//       end
-//     end
-//
-// Now you need to pass this token to JavaScript. You can do so
-// inside a script tag in "web/templates/layout/app.html.eex":
-//
-//     <script>window.userToken = "<%= assigns[:user_token] %>";</script>
-//
-// You will need to verify the user token in the "connect/2" function
-// in "web/channels/user_socket.ex":
-//
-//     def connect(%{"token" => token}, socket) do
-//       # max_age: 1209600 is equivalent to two weeks in seconds
-//       case Phoenix.Token.verify(socket, "user socket", token, max_age: 1209600) do
-//         {:ok, user_id} ->
-//           {:ok, assign(socket, :user, user_id)}
-//         {:error, reason} ->
-//           :error
-//       end
-//     end
-//
-// Finally, pass the token on connect as below. Or remove it
-// from connect if you don't care about authentication.
+let socket = new Socket("/socket", {})
 
 socket.connect()
 
 // Now that you are connected, you can join channels with a topic:
-let channel = socket.channel("topic:subtopic", {})
+let channel = socket.channel("chat", {})
+
+channel.on('message', payload => {
+  $('#chat-box').append(`<div>${payload.message}</div>`);
+});
+
+$('#message-form').submit(e => {
+  e.preventDefault();
+
+  let message = $('#message-input');
+
+  if (message.val().length > 0) {
+    channel.push('message', { message: message.val() });
+    message.val('');
+  }
+});
+
 channel.join()
   .receive("ok", resp => { console.log("Joined successfully", resp) })
   .receive("error", resp => { console.log("Unable to join", resp) })

--- a/rails_v._phoenix_chat/phoenix_chat/web/templates/layout/app.html.eex
+++ b/rails_v._phoenix_chat/phoenix_chat/web/templates/layout/app.html.eex
@@ -8,6 +8,7 @@
     <meta name="author" content="">
 
     <title>Hello PhoenixChat!</title>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
     <link rel="stylesheet" href="<%= static_path(@conn, "/css/app.css") %>">
   </head>
 

--- a/rails_v._phoenix_chat/phoenix_chat/web/templates/page/index.html.eex
+++ b/rails_v._phoenix_chat/phoenix_chat/web/templates/page/index.html.eex
@@ -1,36 +1,10 @@
-<div class="jumbotron">
-  <h2><%= gettext "Welcome to %{name}", name: "Phoenix!" %></h2>
-  <p class="lead">A productive web framework that<br />does not compromise speed and maintainability.</p>
+<h1>Welcome to the Chat Room</h1>
+
+<div id="chat-box">
+  <span>Messages: </span>
 </div>
 
-<div class="row marketing">
-  <div class="col-lg-6">
-    <h4>Resources</h4>
-    <ul>
-      <li>
-        <a href="http://phoenixframework.org/docs/overview">Guides</a>
-      </li>
-      <li>
-        <a href="https://hexdocs.pm/phoenix">Docs</a>
-      </li>
-      <li>
-        <a href="https://github.com/phoenixframework/phoenix">Source</a>
-      </li>
-    </ul>
-  </div>
-
-  <div class="col-lg-6">
-    <h4>Help</h4>
-    <ul>
-      <li>
-        <a href="http://groups.google.com/group/phoenix-talk">Mailing list</a>
-      </li>
-      <li>
-        <a href="http://webchat.freenode.net/?channels=elixir-lang">#elixir-lang on freenode IRC</a>
-      </li>
-      <li>
-        <a href="https://twitter.com/elixirphoenix">@elixirphoenix</a>
-      </li>
-    </ul>
-  </div>
-</div>
+<form id="message-form">
+  <input type="text" id="message-input"/>
+  <input type="submit" />
+</form>


### PR DESCRIPTION
Why:

* So we can document the build process
* Have something to compare/contrast with the Rails chat app

This change addresses the need by:

* Implements a channel for pub/sub
* A JS client for messaging
* Specs